### PR TITLE
Overrides on provided sizes.

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,9 +1,36 @@
 import { DEVICE_SIZES } from './types';
 
-export function deviceSize(width: number) {
-  if (width > 1200) return DEVICE_SIZES.EXTRA_LARGE_DEVICE;
-  if (width > 992) return DEVICE_SIZES.LARGE_DEVICE;
-  if (width > 768) return DEVICE_SIZES.MEDIUM_DEVICE;
-  if (width > 540) return DEVICE_SIZES.SMALL_DEVICE;
-  return DEVICE_SIZES.EXTRA_SMALL_DEVICE;
+export function deviceSize(width?: number, provided_sizes?:object) {
+    //pick smallest available size!? 
+    
+    const devSizeArray = Object.values(DEVICE_SIZES);
+    const pickSmallest = ( size )=>{
+        const index = devSizeArray.indexOf( size );
+
+        for(let i = index; i < devSizeArray.length; i++){
+
+            if ( provided_sizes[ devSizeArray[i] ] ) {
+                return devSizeArray[i];
+            }
+
+        }
+
+        return undefined;
+
+    }
+
+    if (width > 1200) {
+        return pickSmallest( DEVICE_SIZES.EXTRA_LARGE_DEVICE );        
+    }
+    if (width > 992) {
+        return pickSmallest( DEVICE_SIZES.LARGE_DEVICE );
+    }
+    if (width > 768) {
+        return pickSmallest( DEVICE_SIZES.MEDIUM_DEVICE );
+    }
+    if (width > 540) {
+        return pickSmallest( DEVICE_SIZES.SMALL_DEVICE );
+    }
+
+    return pickSmallest( DEVICE_SIZES.EXTRA_SMALL_DEVICE );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,29 +7,19 @@ function CreateResponsiveStyle<GlobalStyles, OverrideStyles extends GlobalStyles
   styleOverrides: Partial<Record<DEVICE_SIZES, StyleSheet.NamedStyles<Partial<OverrideStyles>>>>,
 ) {
   const overrides: StyleSheet.NamedStyles<any> = {};
+  const provided_sizes = {};
 
   // Create custom style names based on the device overrides
   Object.entries(styleOverrides).forEach(([key, value]) => {
     Object.entries(value).forEach(([className, value2]) => {
+      provided_sizes[key] = true;
       overrides[`${key}_${className}`] = value2 as ViewStyle | TextStyle | ImageStyle;
     });
   });
 
-  // Merge the stylesheets example:
-  // {
-  //   container: {
-  //     color: 'red'
-  //   },
-  //   large_container: {
-  //     color: 'blue'
-  //   },
-  //   small_container: {
-  //     color: 'green'
-  //   },
-  // }
   const styles = StyleSheet.create<StyleSheet.NamedStyles<GlobalStyles>>({ ...webStyles, ...overrides });
-
-  return useResponsiveStyle<GlobalStyles>(styles);
+    
+  return useResponsiveStyle<GlobalStyles>(styles, provided_sizes);
 }
 
 export { CreateResponsiveStyle, useResponsiveStyle, DEVICE_SIZES };

--- a/src/useResponsiveStyle.ts
+++ b/src/useResponsiveStyle.ts
@@ -2,11 +2,11 @@ import { StyleSheet } from 'react-native'
 import { deviceSize } from './helpers'
 import useWindowSizes from './useWindowSizes'
 
-export default function useResponsiveStyle<T>(styles: StyleSheet.NamedStyles<any>) {
+export default function useResponsiveStyle<T>(styles: StyleSheet.NamedStyles<any>, provided_sizes) {
   return () => {
-    const layout = useWindowSizes(deviceSize)
-    const size = deviceSize(layout.width)
-
+    const layout = useWindowSizes(deviceSize, provided_sizes)
+    const size = deviceSize(layout.width, provided_sizes);    
+    
     return {
       styles: (style: keyof T) => StyleSheet.compose(styles[style], styles[`${size}_${style}`]),
       deviceSize: size,

--- a/src/useWindowSizes.ts
+++ b/src/useWindowSizes.ts
@@ -6,13 +6,13 @@ import { DEVICE_SIZES } from './types'
  * Hook to watch changes in screenSize and report the dimensions whenever the device size changes
  * @param breakpoints a function that returns the device size given a width
  */
-export default function useWindowSizes(breakpoints: (width: number) => DEVICE_SIZES) {
+export default function useWindowSizes(breakpoints: (width: number, provided_sizes:object) => DEVICE_SIZES, provided_sizes:object) {
   const [dims, setDims] = useState(() => Dimensions.get('window'))
 
   useEffect(() => {
     function handleChange({ window }: { window: ScaledSize }) {
       // Only update the dimensions when the device size changes
-      setDims((prev) => (breakpoints(prev.width) === breakpoints(window.width) ? prev : window))
+      setDims((prev) => (breakpoints(prev.width, provided_sizes) === breakpoints(window.width, provided_sizes) ? prev : window))
     }
 
     const listener = Dimensions.addEventListener('change', handleChange)
@@ -20,9 +20,7 @@ export default function useWindowSizes(breakpoints: (width: number) => DEVICE_SI
     // `addEventListener` in this handler, so we set it here. If there was
     // no change, React will filter out this update as a no-op.
     setDims(Dimensions.get('window'))
-    return () => {
-      listener.remove()
-    }
+    
   }, [])
 
   return dims


### PR DESCRIPTION
Hey there!

This might be a little weird, and I DEFINITELY butchered the code a bit ( so don't merge this I guess, it's for the idea ).

I'm happily using your library in a personal project, I like the idea of breakpoints. However, I don't love the idea of having to provide a style for each breakpoint, so I tried to 'fix' that.

For example: I have a main style where a View is 30% of the window width. For screen sizes smaller than SMALL_DEVICE I want to have the view be the full 100% of the window's width. Now I have to specify that in the SMALL_DEVICE styling ánd the EXTRA_SMALL_DEVICE styling. 

I changed the code in the library so that it searches for the smallest provided override. If the screen is smaller than EXTRA_SMALL_SCREEN, but I only provided a style for SMALL_SCREEN, it will pick that style ( because the width is lower than it's breakpoint ). I feel like that's more like @media rules from CSS..

Like I said, this is for the idea. If you're into it you can use it.

Kind regards,
Ethan Hermsey