### PR TITLE
Fix crashes on React Native version ^0.66 on refresh

### DIFF
--- a/src/useWindowSizes.ts
+++ b/src/useWindowSizes.ts
@@ -20,7 +20,9 @@ export default function useWindowSizes(breakpoints: (width: number) => DEVICE_SI
     // `addEventListener` in this handler, so we set it here. If there was
     // no change, React will filter out this update as a no-op.
     setDims(Dimensions.get('window'))
-    return listener && listener.remove
+    return () => {
+      if(listener) listener.remove();
+    }
   }, [])
 
   return dims


### PR DESCRIPTION
I recently upgraded my project from React Native 0.64.x to 0.68.x, as many other Expo users who have decided to upgrade to SDK 45 may have.

There seems to be an issue in React Native concerning the return value of useEffect handlers, and if it doesn't like the return type it just throws a cryptic error saying:
```
Warning: Internal React error: Attempted to capture a commit phase error inside a detached tree. This indicates a bug in React. Likely causes include deleting the same fiber more than once, committing an already-finished tree, or an inconsistent return pointer. 

Error message:

%s%s, TypeError: undefined is not an object (evaluating 'this.emitter'), 
    in Partnerships (created by ProfileScreen)
    in RCTView (created by View)
   ...
```
![image](https://user-images.githubusercontent.com/8114139/177061671-24b94b52-1e3c-48f9-bcea-901bedfdc943.png)

Anyway, after a quick process of elimination I figured out the source of problem was the return value of the useEffect function of this package. After changing the return value from an expression that returns `undefined | () => void` to `() => void`, the errors stopped appearing and the crashes ceased.

It is a quick and painless 3-liner fix, and even though you've got react-native 0.63 in your dependencies, I thought this might be a good quality-of-life contribution :).

What is interesting is that this was actually causing a crashing on every fast-refresh, although in other cases when I got the same error due to the same thing in my own useEffect functions, it did not crash my app. It's pretty cryptic so I don't even know where to begin, but at least I managed to fix the errors.