### PR TITLE
Make regex stricter and sanitize style names

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const useStyles = CreateResponsiveStyle(
 The currently configured breakpoints are:
 
 |    Size     |               Value               |     Shorthand     |      Breakpoints      |
-|:-----------:|:---------------------------------:|:-----------------:|:---------------------:|
+| :---------: | :-------------------------------: | :---------------: | :-------------------: |
 | extra small | `DEVICE_SIZES.EXTRA_SMALL_DEVICE` | `DEVICE_SIZES.XS` |    `width <= 540`     |
 |    small    |    `DEVICE_SIZES.SMALL_DEVICE`    | `DEVICE_SIZES.SM` | `540 < width <= 768`  |
 |   medium    |   `DEVICE_SIZES.MEDIUM_DEVICE`    | `DEVICE_SIZES.MD` | `768 < width <= 992`  |
@@ -140,8 +140,6 @@ export default function App() {
 
 ## Support for Next.js
 
-:sparkles:Available in 2.1.0:sparkles:
-
 NextJS provides server-side-rendering (SSR) for react-native-web projects. This library supports that by delaying
 rendering until it has reached the client, this is a similar approach used by many other packages, as there is no way to
 know the device size in the server, so responsive styles are meaningless. In order to support SSR you must add this
@@ -161,21 +159,4 @@ export default function App() {
 }
 ```
 
-* You can see the full example in the nexpo-example directory
-
-
-# Upgrading to V2 (from V1)
-
-V2 provides some very useful features like advanced typechecking as well as a more familiar syntax. Instead of using
-functions to call styles, you can simply call them the same way you would normally. This means to gradually adopt this
-library it is as simple as replacing `const styles = Stylesheet.create` with `const useStyles = CreateResponsiveStyles`
-and adding `const styles = useStyles()` inside your component. With this update typechecking will now verify that styles
-are used for appropriate components and that no css only styles are used. In addition, there is support for custom
-breakpoints.
-
-**To upgrade:**
-
-1. Replace `const { styles } = useStyles()` with `const styles = useStyles()`
-2. Replace all styling calls from `styles('container)` to `styles.container`
-3. If you have been using `deviceSize` it is now a standalone hook `const deviceSize = useDeviceSize()`
-
+- You can see the full example in the nexpo-example directory

--- a/src/createResponsiveStyle.ts
+++ b/src/createResponsiveStyle.ts
@@ -27,10 +27,10 @@ function CreateResponsiveStyle<
   //   container: {
   //     color: 'red'
   //   },
-  //   large_container: {
+  //   $$large$$_container: {
   //     color: 'blue'
   //   },
-  //   extrasmall+small_container: {
+  //   $$extrasmall+small$$_container: {
   //     color: 'green'
   //   },
   // }

--- a/src/hooks/useResponsiveStyle.ts
+++ b/src/hooks/useResponsiveStyle.ts
@@ -2,6 +2,15 @@ import { StyleProp, StyleSheet } from 'react-native'
 import useDeviceSize from './useDeviceSize'
 import { DEVICE_SIZES } from '../types'
 
+// Will match any string that contains the sizes (in any order) followed by the class name
+export const matchOverrides = (defaultClass: string, size: string) => {
+  // Sanitize the defaultClass by escaping special regex characters
+  const sanitizedClass = defaultClass.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+  // See regexPatternMatching.test.ts for examples on what should match and not
+  return new RegExp(`^\\$\\$(.*\\+)?${size}(\\+.*)?\\$\\$_${sanitizedClass}$`)
+}
+
 // Will recursively combine all the styles as StyleSheet.compose only takes two arguments
 const composeMultipleStyles = <Styles>(
   styles: StyleSheet.NamedStyles<any>,
@@ -15,19 +24,15 @@ const composeMultipleStyles = <Styles>(
   return StyleSheet.compose(styles[classNames[0]], nextIteration)
 }
 
-const buildCustomStyleMap = <Styles>(styles: StyleSheet.NamedStyles<any>, size: DEVICE_SIZES) => {
+const buildCustomStyleMap = (styles: StyleSheet.NamedStyles<any>, size: DEVICE_SIZES) => {
   const styleObj: StyleProp<any> = {}
 
-  // Will match any string that contains the sizes (in any order) followed by the class name
-  const matchOverrides = (defaultClass: string) =>
-    new RegExp(`(^\\$\\$|.*\\+)${size}[a-zA-Z0-9+-]*\\$\\$_${defaultClass}$`)
-
-  // Will get a list the base styles excluding all overrides
+  // Will get a list of the base styles excluding all overrides
   const defaultKeys = Object.keys(styles).filter((style) => !style.startsWith('$$'))
 
   defaultKeys.forEach((key) => {
     // Get all overrides for a certain class
-    const styleOverrides = Object.keys(styles).filter((style) => style.match(matchOverrides(key)))
+    const styleOverrides = Object.keys(styles).filter((style) => style.match(matchOverrides(key, size)))
 
     // Combine the base style and any overrides to get the computed style
     styleObj[key] = composeMultipleStyles(styles, [key, ...styleOverrides])

--- a/tests/regexPatternMatching.test.ts
+++ b/tests/regexPatternMatching.test.ts
@@ -1,0 +1,38 @@
+import { matchOverrides } from '../src/hooks/useResponsiveStyle'
+import { DEVICE_SIZES } from '../src'
+
+describe('test that regex pattern correctly matches style overrides', () => {
+  test.each([
+    ['text', DEVICE_SIZES.SM, '$$extrasmall+small$$_text', true],
+    ['text', DEVICE_SIZES.SM, '$$small$$_text', true],
+    ['text', DEVICE_SIZES.SM, '$$small+large$$_text', true],
+    ['text', DEVICE_SIZES.SM, '$extrasmall+small$$_text', false],
+    ['text', DEVICE_SIZES.SM, '$$small$_text', false],
+    ['text', DEVICE_SIZES.SM, '$$smalllarge$$_text', false],
+    ['text', DEVICE_SIZES.SM, '$$small+large$$_text', true],
+    ['text', DEVICE_SIZES.SM, 'text', false],
+  ])("'%s' style name with '%s' size should match '%s': %s", (defaultClass, size, testString, expected) => {
+    const regex = matchOverrides(defaultClass, size)
+    expect(regex.test(testString)).toBe(expected)
+  })
+
+  test.each([
+    ['$container', DEVICE_SIZES.SM, '$$extrasmall+small$$_$container', true],
+    ['$container', DEVICE_SIZES.SM, '$$small$$_$container', true],
+    ['$container', DEVICE_SIZES.SM, '$$small+large$$_$container', true],
+    ['$container', DEVICE_SIZES.SM, '$$small+large$$_container', false],
+    ['$container', DEVICE_SIZES.SM, '$extrasmall+small$$_container', false],
+    ['$container', DEVICE_SIZES.SM, '$$small$_container', false],
+    ['$container', DEVICE_SIZES.SM, '$$smalllarge$$_container', false],
+    ['$container', DEVICE_SIZES.SM, 'container', false],
+    ['[special]', DEVICE_SIZES.MD, '$$medium$$_[special]', true],
+    ['[special]', DEVICE_SIZES.MD, '$$large+medium$$_[special]', true],
+    ['[special]', DEVICE_SIZES.MD, 'medium$$_[special]', false],
+    ['[special]', DEVICE_SIZES.MD, '$$medium_[special]', false],
+    ['[special]', DEVICE_SIZES.MD, 'large+medium_[special]', false],
+    ['[special]', DEVICE_SIZES.MD, 'randomString', false],
+  ])("'%s' style name with '%s' size should match '%s': %s", (defaultClass, size, testString, expected) => {
+    const regex = matchOverrides(defaultClass, size)
+    expect(regex.test(testString)).toBe(expected)
+  })
+})


### PR DESCRIPTION
This change will make the regex matching stricter for classes as well as escape special characters in style names so that any valid string can be used as a style name without messing with the underlying functionality.

closes #24 